### PR TITLE
fix: Disable auto deploy Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+} 


### PR DESCRIPTION
Vercel auto deploys on every single push, we want to stop that. I will create the deployment pipelines later for test and prod to make it deploy without needing auto deploys directly.