### PR TITLE
fix: Reusable deployment workflow issues

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: 'Production'
+      environment: 'production'
       is_production: true
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   deploy-prd:
+    permissions:
+      deployments: write
+      contents: read
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'Production'

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -12,3 +12,6 @@ jobs:
     with:
       environment: 'Production'
       is_production: true
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -14,4 +14,3 @@ jobs:
       is_production: true
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   deploy-preview:
+    permissions:
+      deployments: write
+      contents: read
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'Preview'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: 'Preview'
+      environment: 'preview'
       is_production: false
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,4 +17,3 @@ jobs:
       is_production: false
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,3 +15,6 @@ jobs:
     with:
       environment: 'Preview'
       is_production: false
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,14 +37,10 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
-      - name: Set GitHub deployment environment name
+      - name: Set GitHub deployment environment name (Capitalized first letter)
         id: set-env
         run: |
-          if [ "${{ inputs.environment }}" = "preview" ]; then
-            echo "GITHUB_DEPLOYMENT_ENV=Preview" >> $GITHUB_ENV
-          else
-            echo "GITHUB_DEPLOYMENT_ENV=Production" >> $GITHUB_ENV
-          fi
+          echo "GITHUB_DEPLOYMENT_ENV=${${{ inputs.environment }}^}" >> $GITHUB_ENV
 
       - name: Link Vercel Project
         working-directory: ide

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: boolean
         description: 'Whether this is a production deployment'
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   deploy:
@@ -36,11 +41,11 @@ jobs:
 
       - name: Link Vercel Project
         working-directory: ide
-        run: vercel link --yes --project=themed-ide --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel link --yes --project=themed-ide --token=${{ inputs.VERCEL_TOKEN }}
 
       - name: Pull Vercel Environment Information
         working-directory: ide
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ inputs.VERCEL_TOKEN }}
 
       - name: Create GitHub Deployment
         id: deployment
@@ -60,7 +65,7 @@ jobs:
       - name: Update GitHub Deployment Status (In Progress)
         run: |
           python scripts/github_deployment.py \
-            "${{ secrets.GITHUB_TOKEN }}" \
+            "${{ inputs.GITHUB_TOKEN }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "in_progress" \
@@ -68,20 +73,20 @@ jobs:
 
       - name: Build Project Artifacts
         working-directory: ide
-        run: vercel build ${{ inputs.is_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ inputs.is_production && '--prod' || '' }} --token=${{ inputs.VERCEL_TOKEN }}
         
       - name: Deploy Project Artifacts to Vercel
         id: vercel-deploy
         working-directory: ide
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt ${{ inputs.is_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }} | grep -o 'https://[^ ]*\.vercel\.app')
+          DEPLOY_URL=$(vercel deploy --prebuilt ${{ inputs.is_production && '--prod' || '' }} --token=${{ inputs.VERCEL_TOKEN }} | grep -o 'https://[^ ]*\.vercel\.app')
           echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
 
       - name: Update GitHub Deployment Status (Success)
         if: success()
         run: |
           python scripts/github_deployment.py \
-            "${{ secrets.GITHUB_TOKEN }}" \
+            "${{ inputs.GITHUB_TOKEN }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "success" \
@@ -92,7 +97,7 @@ jobs:
         if: failure()
         run: |
           python scripts/github_deployment.py \
-            "${{ secrets.GITHUB_TOKEN }}" \
+            "${{ inputs.GITHUB_TOKEN }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "failure" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Link Vercel Project
         working-directory: ide
-        run: vercel link --yes --project=themed-ide --token=${{ inputs.VERCEL_TOKEN }}
+        run: vercel link --yes --project=themed-ide --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Pull Vercel Environment Information
         working-directory: ide
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ inputs.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Create GitHub Deployment
         id: deployment
@@ -71,13 +71,13 @@ jobs:
 
       - name: Build Project Artifacts
         working-directory: ide
-        run: vercel build ${{ inputs.is_production && '--prod' || '' }} --token=${{ inputs.VERCEL_TOKEN }}
+        run: vercel build ${{ inputs.is_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
         
       - name: Deploy Project Artifacts to Vercel
         id: vercel-deploy
         working-directory: ide
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt ${{ inputs.is_production && '--prod' || '' }} --token=${{ inputs.VERCEL_TOKEN }} | grep -o 'https://[^ ]*\.vercel\.app')
+          DEPLOY_URL=$(vercel deploy --prebuilt ${{ inputs.is_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }} | grep -o 'https://[^ ]*\.vercel\.app')
           echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
 
       - name: Update GitHub Deployment Status (Success)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
+      - name: Set GitHub deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ inputs.environment }}" = "preview" ]; then
+            echo "GITHUB_DEPLOYMENT_ENV=Preview" >> $GITHUB_ENV
+          else
+            echo "GITHUB_DEPLOYMENT_ENV=Production" >> $GITHUB_ENV
+          fi
+
       - name: Link Vercel Project
         working-directory: ide
         run: vercel link --yes --project=themed-ide --token=${{ secrets.VERCEL_TOKEN }}
@@ -54,7 +63,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              environment: '${{ inputs.environment }}',
+              environment: '${{ env.GITHUB_DEPLOYMENT_ENV }}',
               auto_merge: false,
               required_contexts: []
             });
@@ -67,7 +76,7 @@ jobs:
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "in_progress" \
-            "${{ inputs.environment }}"
+            "${{ env.GITHUB_DEPLOYMENT_ENV }}"
 
       - name: Build Project Artifacts
         working-directory: ide
@@ -88,7 +97,7 @@ jobs:
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "success" \
-            "${{ inputs.environment }}" \
+            "${{ env.GITHUB_DEPLOYMENT_ENV }}" \
             "${{ env.DEPLOY_URL }}"
 
       - name: Update GitHub Deployment Status (Failure)
@@ -99,4 +108,4 @@ jobs:
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "failure" \
-            "${{ inputs.environment }}" 
+            "${{ env.GITHUB_DEPLOYMENT_ENV }}" 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ on:
     secrets:
       VERCEL_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   deploy:
@@ -65,7 +63,7 @@ jobs:
       - name: Update GitHub Deployment Status (In Progress)
         run: |
           python scripts/github_deployment.py \
-            "${{ inputs.GITHUB_TOKEN }}" \
+            "${{ github.token }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "in_progress" \
@@ -86,7 +84,7 @@ jobs:
         if: success()
         run: |
           python scripts/github_deployment.py \
-            "${{ inputs.GITHUB_TOKEN }}" \
+            "${{ github.token }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "success" \
@@ -97,7 +95,7 @@ jobs:
         if: failure()
         run: |
           python scripts/github_deployment.py \
-            "${{ inputs.GITHUB_TOKEN }}" \
+            "${{ github.token }}" \
             "${{ github.repository }}" \
             "${{ steps.deployment.outputs.result }}" \
             "failure" \


### PR DESCRIPTION
- Moved permissions into standalone environment deployment workflows
- Passing Vercel token to workflow call
   - Reusable workflows can't directly retrieve secrets
- Setting up a `GITHUB_DEPLOYMENT_ENV` variable
   - This is needed because we want the first letter capitalized