### PR TITLE
feat: Adding submodule for iterm2 color schemes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ide"]
 	path = ide
 	url = https://github.com/judge0/ide.git
+[submodule "iTerm2-Color-Schemes"]
+	path = iTerm2-Color-Schemes
+	url = https://github.com/mbadolato/iTerm2-Color-Schemes.git


### PR DESCRIPTION
- Adding the submodule ([Repo link](https://github.com/mbadolato/iTerm2-Color-Schemes)).
- Not sure which folder we will use for this (`schema/`, `ghostty/` or `vscode/` more than likely).