### PR TITLE
fix: Add default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@ianuriegas
+* @ianuriegas


### PR DESCRIPTION
It needs a star in the front.