### PR TITLE
test: Delete `.vercel.approvers`

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,1 +1,0 @@
-@ianuriegas


### PR DESCRIPTION
I believe this can be safely deleted as it is probably redundant. I will monitor to see if anything is weird with deployments but I believe everything should be alright considering we are using a Vercel token.